### PR TITLE
[Finished #148456371] Add Default Active Status to Food

### DIFF
--- a/database-spike.js
+++ b/database-spike.js
@@ -3,25 +3,12 @@ const configuration = require('./knexfile')[environment]
 const database = require('knex')(configuration)
 
 database.raw(
-  'INSERT INTO foods (name, calories, active, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
-  ["crepe", 100, 1, new Date(), new Date()]
+  'INSERT INTO foods (name, calories, created_at, updated_at) VALUES (?, ?, ?, ?)',
+  ["soup", 40, new Date(), new Date()]
 ).then(function() {
   database.raw('SELECT * FROM foods')
     .then(function(data) {
       console.log(data.rows)
       process.exit()
     })
-})
-
-database.raw(
-  'INSERT INTO foods (name, calories, active, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
-  ['foo', 888, true, new Date(), new Date()]
-).then(function() {
-  var result = database.raw(
-    'SELECT * FROM foods WHERE name=?', ['bar']
-    )
-
-  console.log(result)
-}).then(function() {
-  process.exit()
 })

--- a/db/migrations/20170707232216_change_active_column_default.js
+++ b/db/migrations/20170707232216_change_active_column_default.js
@@ -1,0 +1,9 @@
+exports.up = function(knex, Promise) {
+  let alterQuery = `ALTER TABLE foods ALTER COLUMN active SET DEFAULT true`
+  return knex.raw(alterQuery)
+};
+
+exports.down = function(knex, Promise) {
+  let downQuery = `ALTER TABLE foods ALTER COLUMN active DROP DEFAULT`
+  return knex.raw(downQuery)
+};

--- a/db/seeds/dev/foods.js
+++ b/db/seeds/dev/foods.js
@@ -3,20 +3,20 @@ exports.seed = function(knex, Promise) {
     .then(function () {
       return Promise.all([
         knex.raw(
-          'INSERT INTO foods (name, calories, active, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
-          ["banana", 200, true, new Date(), new Date()]
+          'INSERT INTO foods (name, calories, created_at, updated_at) VALUES (?, ?, ?, ?)',
+          ["banana", 200, new Date(), new Date()]
         ),
         knex.raw(
-          'INSERT INTO foods (name, calories, active, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
-          ["crepe", 230, true, new Date(), new Date()]
+          'INSERT INTO foods (name, calories, created_at, updated_at) VALUES (?, ?, ?, ?)',
+          ["crepe", 230, new Date(), new Date()]
         ),
         knex.raw(
-          'INSERT INTO foods (name, calories, active, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
-          ["croissant", 280, true, new Date(), new Date()]
+          'INSERT INTO foods (name, calories, created_at, updated_at) VALUES (?, ?, ?, ?)',
+          ["croissant", 280, new Date(), new Date()]
         ),
         knex.raw(
-          'INSERT INTO foods (name, calories, active, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
-          ["baguette", 200, false, new Date(), new Date()]
+          'INSERT INTO foods (name, calories, created_at, updated_at) VALUES (?, ?, ?, ?)',
+          ["baguette", 200, new Date(), new Date()]
         )
       ])
     })

--- a/lib/models/food.js
+++ b/lib/models/food.js
@@ -7,10 +7,10 @@ function all() {
   return database.raw('SELECT * FROM foods')
 }
 
-function createFood(name, calories, active) {
+function createFood(name, calories) {
   return database.raw(
-    'INSERT INTO foods (name, calories, active, created_at, updated_at) VALUES (?,?,?,?,?)',
-    [name, calories, active, new Date(), new Date()]
+    'INSERT INTO foods (name, calories, created_at, updated_at) VALUES (?,?,?,?)',
+    [name, calories, new Date(), new Date()]
   )
 }
 

--- a/server.js
+++ b/server.js
@@ -41,7 +41,6 @@ app.get('/api/v1/foods/:id', function(request, response) {
 app.post('/api/v1/foods', function(request, response) {
   var name = request.body.name
   var calories = request.body.calories
-  var active = request.body.active
 
   // if (!name) {
   //   return response.status(422).send({
@@ -49,15 +48,13 @@ app.post('/api/v1/foods', function(request, response) {
   //   })
   // }
 
-  Food.createFood(name, calories, active)
+  Food.createFood(name, calories)
   .then(function() {
     Food.findByName(name)
     .then(function(data) {
       response.json(data.rows[0])
     })
   })
-
-  // eval(pry.it);
 
   //   if (error)
   //   response.send(error)

--- a/test/endpoints/server-test.js
+++ b/test/endpoints/server-test.js
@@ -41,11 +41,11 @@ describe('Server', function() {
 
   describe('GET /api/v1/foods', function() {
     beforeEach(function(done) {
-      Food.createFood('banana', 200, true)
+      Food.createFood('banana', 200)
         .then(function() {
-          Food.createFood('taco', 400, false)
+          Food.createFood('taco', 400)
             .then(function() {
-              Food.createFood('cheetos', 150, false)
+              Food.createFood('cheetos', 150)
                 .then(function() { done() })
             })
         })
@@ -76,9 +76,9 @@ describe('Server', function() {
 
   describe('GET /api/v1/foods/:id', function() {
     beforeEach(function(done) {
-      Food.createFood('banana', 200, true)
+      Food.createFood('banana', 200)
         .then(function() {
-          Food.createFood('taco', 400, false)
+          Food.createFood('taco', 400)
             .then(function() { done() })
         })
     })
@@ -126,7 +126,7 @@ describe('Server', function() {
         assert.equal(parsedFood.id, id)
         assert.equal(parsedFood.name, 'taco')
         assert.equal(parsedFood.calories, 400)
-        assert.equal(parsedFood.active, false)
+        assert.equal(parsedFood.active, true)
         assert.ok(parsedFood.created_at)
         assert.ok(parsedFood.updated_at)
         done()
@@ -135,12 +135,10 @@ describe('Server', function() {
   })
 
   describe('POST /api/v1/foods', function() {
-    this.timeout(10000000)
-
     beforeEach(function(done) {
-      Food.createFood('banana', 200, true)
+      Food.createFood('banana', 200)
       .then(function() {
-        Food.createFood('taco', 400, false)
+        Food.createFood('taco', 400)
         .then(function() { done() })
       })
     })
@@ -156,8 +154,7 @@ describe('Server', function() {
           json: true,
           body: {
             name: 'pasta',
-            calories: 200,
-            active: true
+            calories: 200
           }
       }
 
@@ -176,9 +173,9 @@ describe('Server', function() {
 
   describe('PUT /api/v1/foods/:id', function() {
     beforeEach(function(done) {
-      Food.createFood('banana', 200, true)
+      Food.createFood('banana', 200)
         .then(function() {
-          Food.createFood('taco', 400, false)
+          Food.createFood('taco', 400)
             .then(function() { done() })
         })
     })
@@ -226,7 +223,7 @@ describe('Server', function() {
         assert.equal(response.body.id, 2)
         assert.equal(response.body.name, 'taco')
         assert.equal(response.body.calories, 5000)
-        assert.equal(response.body.active, false)
+        assert.equal(response.body.active, true)
         assert.ok(response.body.created_at)
         assert.notEqual(response.body.updated_at, response.body.created_at)
         done()
@@ -261,9 +258,9 @@ describe('Server', function() {
 
   describe('DELETE /api/v1/foods/:id', function() {
     beforeEach(function(done) {
-      Food.createFood('banana', 200, true)
+      Food.createFood('banana', 200)
         .then(function() {
-          Food.createFood('taco', 400, false)
+          Food.createFood('taco', 400)
             .then(function() { done() })
         })
     })
@@ -294,7 +291,7 @@ describe('Server', function() {
           assert.equal(parsedFood.length, 1)
           assert.equal(parsedFood[0].name, 'taco')
           assert.equal(parsedFood[0].calories, 400)
-          assert.equal(parsedFood[0].active, false)
+          assert.equal(parsedFood[0].active, true)
           assert.ok(parsedFood[0].created_at)
           assert.ok(parsedFood[0].updated_at)
           done()

--- a/test/models/food-test.js
+++ b/test/models/food-test.js
@@ -5,7 +5,7 @@ process.env.NODE_ENV = 'test'
 
 describe('Food', function() {
   beforeEach(function(done) {
-    Food.createFood('pizza', 1000, true)
+    Food.createFood('pizza', 1000)
       .then(function() { done() })
   })
 
@@ -16,7 +16,7 @@ describe('Food', function() {
 
   describe('methods', function() {
     it('.all', function(done) {
-      Food.createFood('cheeseburger', 800, true)
+      Food.createFood('cheeseburger', 800)
         .then(function() {
           Food.all()
             .then(function(data) {


### PR DESCRIPTION
@somedayrainbows @case-eee 

This PR will set the default value of the active column in the foods table to true, because a food should never be created with an active status of false. Therefore, the createFood method no longer requires an argument for this column. Everywhere this function is invoked throughout the project, I have remove the active argument. All tests are passing and all food endpoints work in development. After merging this branch into master and pulling down locally, migrations must be run and the database must be re-seeded. Closes PT issue #148456371.