### PR TITLE
[Finished #148527387] Modify Food Delete Endpoint

### DIFF
--- a/lib/models/food.js
+++ b/lib/models/food.js
@@ -43,8 +43,8 @@ function update(id, payload) {
   }
 }
 
-function destroy(id) {
-  return database.raw('DELETE FROM foods WHERE id=?', [id])
+function deactivate(id) {
+  return database.raw('UPDATE foods SET active=?, updated_at=? WHERE id=?', [false, new Date(), id])
 }
 
 module.exports = {
@@ -54,5 +54,5 @@ module.exports = {
   find: find,
   update: update,
   findByName: findByName,
-  destroy: destroy
+  deactivate: deactivate
 }

--- a/server.js
+++ b/server.js
@@ -81,7 +81,7 @@ app.put('/api/v1/foods/:id', function (request, response) {
 app.delete('/api/v1/foods/:id', function (request, response) {
   var id = request.params.id
 
-  Food.destroy(id)
+  Food.deactivate(id)
     .then(function() {
       Food.all()
         .then(function(data) {

--- a/test/endpoints/server-test.js
+++ b/test/endpoints/server-test.js
@@ -286,17 +286,26 @@ describe('Server', function() {
         if(error) { done(error) }
         assert.equal(response.statusCode, 200)
 
-        ourRequest.get('api/v1/foods', function(error, response) {
+        var parsedFood = JSON.parse(response.body)
+
+        assert.equal(parsedFood.length, 2)
+        assert.equal(parsedFood[0].name, 'taco')
+        assert.equal(parsedFood[0].calories, 400)
+        assert.equal(parsedFood[0].active, false)
+        assert.ok(parsedFood[0].created_at)
+        assert.ok(parsedFood[0].updated_at)
+
+        ourRequest.get('api/v1/foods/1', function(error, response) {
           if(error) { done(error) }
+          assert.equal(response.statusCode, 200)
 
-          var parsedFood = JSON.parse(response.body)
+          var deletedFood = JSON.parse(response.body)
 
-          assert.equal(parsedFood.length, 1)
-          assert.equal(parsedFood[0].name, 'taco')
-          assert.equal(parsedFood[0].calories, 400)
-          assert.equal(parsedFood[0].active, false)
-          assert.ok(parsedFood[0].created_at)
-          assert.ok(parsedFood[0].updated_at)
+          assert.equal(deletedFood.name, 'banana')
+          assert.equal(deletedFood.calories, 200)
+          assert.equal(deletedFood.active, false)
+          assert.ok(deletedFood.created_at)
+          assert.ok(deletedFood.updated_at)
           done()
         })
       })


### PR DESCRIPTION
@somedayrainbows @case-eee 

This PR will modify the delete food endpoint so that the active boolean column will be changed to false, essentially deactivating the food but still keeping it in the database. Originally it deleted the food record from the foods table altogether. No new migrations need to be run with this PR. All tests are passing and all food endpoints work in development.

Closes PT issue #148527387.