### PR TITLE
[Finished #148519027] Post to Meal

### DIFF
--- a/lib/models/meal.js
+++ b/lib/models/meal.js
@@ -30,11 +30,22 @@ function destroy(id) {
   return database.raw('DELETE FROM meals WHERE id=?', [id])
 }
 
+function foods(meal_id) {
+  return database.raw(
+    `SELECT f.*
+    FROM meals AS m
+    INNER JOIN meal_foods AS mf ON m.id = mf.meal_id
+    INNER JOIN foods AS f ON mf.food_id = f.id
+    WHERE m.id=?`, [meal_id]
+  )
+}
+
 module.exports = {
   all: all,
   createMeal: createMeal,
   emptyMealsTable: emptyMealsTable,
   find: find,
   findByName: findByName,
-  destroy: destroy
+  destroy: destroy,
+  foods: foods
 }

--- a/lib/models/mealFood.js
+++ b/lib/models/mealFood.js
@@ -1,0 +1,17 @@
+const environment = process.env.NODE_ENV || 'development'
+const configuration = require('../../knexfile')[environment]
+const database = require('knex')(configuration)
+
+
+function createMealFood(food_id, meal_id) {
+  return database.raw('INSERT INTO meal_foods (food_id, meal_id, created_at) VALUES (?,?,?)', [food_id, meal_id, new Date()])
+}
+
+function emptyMealFoodsTable() {
+  return database.raw('TRUNCATE meal_foods RESTART IDENTITY')
+}
+
+module.exports = {
+  createMealFood: createMealFood,
+  emptyMealFoodsTable: emptyMealFoodsTable
+}

--- a/routes/meals.js
+++ b/routes/meals.js
@@ -8,10 +8,11 @@ var MealFood = require('../lib/models/mealFood')
 router.get('/api/v1/meals/:id', function(request, response) {
   var id = request.params.id
 
-  Meal.find(id)
+  Meal.foods(id)
     .then(function(data) {
-      if(data.rowCount == 0) { return response.sendStatus(404) }
-      response.json(data.rows[0])
+      if(data.rowCount == 0) { return response.status(404).send({ message: 'This meal has no foods' }) }
+
+      response.json(data.rows)
     })
 })
 

--- a/routes/meals.js
+++ b/routes/meals.js
@@ -1,6 +1,8 @@
 var express = require('express')
 var router = express.Router()
+var Food = require('../lib/models/food')
 var Meal = require('../lib/models/meal')
+var MealFood = require('../lib/models/mealFood')
 
 
 router.get('/api/v1/meals/:id', function(request, response) {
@@ -10,6 +12,33 @@ router.get('/api/v1/meals/:id', function(request, response) {
     .then(function(data) {
       if(data.rowCount == 0) { return response.sendStatus(404) }
       response.json(data.rows[0])
+    })
+})
+
+router.post('/api/v1/meals/:id', function(request, response) {
+  var idMeal = parseInt(request.params.id, 10)
+  var name = request.body.name
+
+  Meal.find(idMeal)
+    .then(function(data) {
+      if(data.rowCount == 0) { return response.sendStatus(404) }
+    })
+
+  Food.findByName(name)
+    .then(function(data) {
+      if(data.rowCount == 0) { return response.sendStatus(404) }
+
+      var idFood = data.rows[0].id
+
+      MealFood.createMealFood(idFood, idMeal)
+        .then(function() {
+          Meal.foods(idMeal)
+            .then(function(data) {
+              if(data.rowCount == 0) {return response.sendStatus(404)}
+
+              response.json(data.rows)
+            })
+        })
     })
 })
 

--- a/test/endpoints/server-test.js
+++ b/test/endpoints/server-test.js
@@ -22,7 +22,6 @@ describe('Server', function() {
     this.server.close()
   })
 
-
   it('exists', function() {
     assert(app)
   })
@@ -98,7 +97,6 @@ describe('Server', function() {
       Food.emptyFoodsTable().then(function() { done() })
     })
 
-
     it('should return a 404 if the resource is not found', function(done) {
       this.request.get('/api/v1/foods/100000', function(error, response) {
         if(error) { done(error) }
@@ -145,6 +143,7 @@ describe('Server', function() {
     })
   })
 
+
   describe('POST /api/v1/foods', function() {
     beforeEach(function(done) {
       Food.createFood('banana', 200)
@@ -160,27 +159,28 @@ describe('Server', function() {
 
     it('should receive and store data', function(done) {
       var postOptions = {
-          url: '/api/v1/foods',
-          method: 'POST',
-          json: true,
-          body: {
-            name: 'pasta',
-            calories: 200
-          }
+        url: '/api/v1/foods',
+        method: 'POST',
+        json: true,
+        body: {
+          name: 'pasta',
+          calories: 200
+        }
       }
 
-    this.request(postOptions, function(error, response) {
-      if (error) { done(error) }
+      this.request(postOptions, function(error, response) {
+        if(error) { done(error) }
 
-      assert.equal(response.body.id, 3)
-      assert.equal(response.body.name, "pasta")
-      assert.equal(response.body.calories, 200)
-      assert.equal(response.body.active, true)
-      assert.ok(response.body.created_at)
-      done()
+        assert.equal(response.body.id, 3)
+        assert.equal(response.body.name, "pasta")
+        assert.equal(response.body.calories, 200)
+        assert.equal(response.body.active, true)
+        assert.ok(response.body.created_at)
+        done()
       })
     })
   })
+
 
   describe('PUT /api/v1/foods/:id', function() {
     beforeEach(function(done) {
@@ -280,7 +280,6 @@ describe('Server', function() {
       Food.emptyFoodsTable().then(function() { done() })
     })
 
-
     it('should delete a food given an id', function(done) {
       var id = 1
       var ourRequest = this.request
@@ -320,19 +319,38 @@ describe('Server', function() {
     })
   })
 
+
   describe('GET /api/v1/meals/:id', function() {
     beforeEach(function(done) {
       Meal.createMeal('Breakfast', 400)
         .then(function() {
           Meal.createMeal('Lunch', 600)
-            .then(function() { done() })
+            .then(function() {
+              Food.createFood('Hot Wings', 555)
+                .then(function() {
+                  Food.createFood('French Fries', 444)
+                    .then(function() {
+                      MealFood.createMealFood(1, 2)
+                        .then(function() {
+                          MealFood.createMealFood(2, 2)
+                            .then(function() { done() })
+                        })
+                    })
+                })
+            })
         })
     })
 
     afterEach(function(done) {
-      Meal.emptyMealsTable().then(function() { done() })
+      Meal.emptyMealsTable()
+        .then(function() {
+          Food.emptyFoodsTable()
+            .then(function() {
+              MealFood.emptyMealFoodsTable()
+                .then(function() { done() })
+            })
+        })
     })
-
 
     it('should return a 404 if the resource is not found', function(done) {
       this.request.get('/api/v1/meals/100000', function(error, response) {
@@ -344,23 +362,20 @@ describe('Server', function() {
       })
     })
 
-    it('should find a meal by id', function(done) {
+    it('should find a meal by id without any associated foods', function(done) {
       var id = 1
 
       this.request.get('/api/v1/meals/' + id, function(error, response) {
         if(error) { done(error) }
 
-        var parsedMeal = JSON.parse(response.body)
+        var message = JSON.parse(response.body).message
 
-        assert.equal(parsedMeal.id, id)
-        assert.equal(parsedMeal.name, 'Breakfast')
-        assert.equal(parsedMeal.goal_calories, 400)
-        assert.ok(parsedMeal.created_at)
+        assert.equal(message, 'This meal has no foods')
         done()
       })
     })
 
-    it('should find a different meal by id', function(done) {
+    it('should find a different meal by id and display its associated foods', function(done) {
       var id = 2
 
       this.request.get('/api/v1/meals/' + id, function(error, response) {
@@ -368,10 +383,19 @@ describe('Server', function() {
 
         var parsedMeal = JSON.parse(response.body)
 
-        assert.equal(parsedMeal.id, id)
-        assert.equal(parsedMeal.name, 'Lunch')
-        assert.equal(parsedMeal.goal_calories, 600)
-        assert.ok(parsedMeal.created_at)
+        assert.equal(parsedMeal.length, 2)
+        assert.equal(parsedMeal[0].id, 1)
+        assert.equal(parsedMeal[0].name, 'Hot Wings')
+        assert.equal(parsedMeal[0].calories, 555)
+        assert.equal(parsedMeal[0].active, true)
+        assert.ok(parsedMeal[0].created_at)
+        assert.ok(parsedMeal[0].updated_at)
+        assert.equal(parsedMeal[1].id, 2)
+        assert.equal(parsedMeal[1].name, 'French Fries')
+        assert.equal(parsedMeal[1].calories, 444)
+        assert.equal(parsedMeal[1].active, true)
+        assert.ok(parsedMeal[1].created_at)
+        assert.ok(parsedMeal[1].updated_at)
         done()
       })
     })
@@ -379,8 +403,6 @@ describe('Server', function() {
 
 
   describe('POST /api/v1/meals/:id', function() {
-    this.timeout(100000000)
-
     beforeEach(function(done) {
       Meal.createMeal('Breakfast', 400)
         .then(function() {


### PR DESCRIPTION
@somedayrainbows @case-eee 

This PR will allow for a POST request to be made to a single meal endpoint using the meal's id and the name of an existing food. The endpoint will return a JSON object consisting of the meal's associated foods. This PR also modifies the GET request to a single meal's endpoint by displaying the meal's associated foods as well. Previously it displayed the single meal's data from the meals table. No migrations need to be run for this PR and no changes were made to the seed files. All tests are passing.

Closes PT issue #148519027.